### PR TITLE
feat!: Upgrade Lambda module version to 8.0

### DIFF
--- a/examples/cloudwatch-log-retention-manager/README.md
+++ b/examples/cloudwatch-log-retention-manager/README.md
@@ -23,8 +23,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 
 ## Providers
 

--- a/examples/cloudwatch-log-retention-manager/versions.tf
+++ b/examples/cloudwatch-log-retention-manager/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.64"
+      version = ">= 6.28"
     }
   }
 }

--- a/modules/cloudwatch-log-retention-manager/README.md
+++ b/modules/cloudwatch-log-retention-manager/README.md
@@ -27,7 +27,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | terraform-aws-modules/eventbridge/aws | ~> 2.3 |
-| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 5.0 |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 8.0 |
 
 ## Resources
 

--- a/modules/cloudwatch-log-retention-manager/README.md
+++ b/modules/cloudwatch-log-retention-manager/README.md
@@ -15,8 +15,8 @@ This Terraform module is the part of [serverless.tf framework](https://github.co
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 
 ## Providers
 

--- a/modules/cloudwatch-log-retention-manager/main.tf
+++ b/modules/cloudwatch-log-retention-manager/main.tf
@@ -7,7 +7,7 @@ locals {
 ##################
 module "lambda_function" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 5.0"
+  version = "~> 8.0"
 
   create = local.create
 

--- a/modules/cloudwatch-log-retention-manager/versions.tf
+++ b/modules/cloudwatch-log-retention-manager/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.57"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {

--- a/modules/cloudwatch-log-retention-manager/versions.tf
+++ b/modules/cloudwatch-log-retention-manager/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.57"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.64"
+      version = ">= 6.28"
     }
   }
 }


### PR DESCRIPTION
## Description
Update the lambda module to version 8 to nullify the depreciation warning for `region.current.name`

## Motivation and Context
The module produces a Depreciation warning for `region.current.name` from the `lambda_function_arn_static` output.
Version 8 of the Lambda module, which requires version 6 of the AWS provider, has been updated with the correct `region` attribute in the output.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Yes. Version 6 of the AWS provider will be required to run the updated version
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- ✅  I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- ✅  I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
- ✅ I have used my fork to apply to a dev environment
